### PR TITLE
py/train: use logsig instead of logsig.exp() to calculate kl_div for …

### DIFF
--- a/mortal/common.py
+++ b/mortal/common.py
@@ -11,6 +11,14 @@ def apply_masks(actions, masks, fill: float = -1e9):
     fill = torch.tensor(fill, dtype=actions.dtype, device=actions.device)
     return torch.where(masks, actions, fill)
 
+@torch.jit.script
+def normal_kl_div(mu_p, logsig_p, mu_q, logsig_q):
+    # KL(N(\mu_p, \sigma_p) \| N(\mu_q, \sigma_q)) = \log \frac{\sigma_q}{\sigma_p} + \frac{\sigma_p^2 + (\mu_p - \mu_q)^2}{2 \sigma_q^2} - \frac{1}{2}
+    return logsig_q - logsig_p + \
+        ((2 * logsig_p).exp() + (mu_p - mu_q) ** 2) / \
+        (2 * (2 * logsig_q).exp()) - \
+        0.5
+
 def hard_update(src, dst):
     dst.load_state_dict(src.state_dict())
 

--- a/mortal/train.py
+++ b/mortal/train.py
@@ -13,11 +13,11 @@ def train():
     from torch import optim
     from torch.cuda import amp
     from torch.nn import functional as F
-    from torch.distributions import Normal, kl_divergence
+    from torch.distributions import Normal
     from torch.utils.data import DataLoader
     from torch.utils.tensorboard import SummaryWriter
     from tqdm.auto import tqdm
-    from common import submit_param, parameter_count, drain
+    from common import normal_kl_div, submit_param, parameter_count, drain
     from player import TestPlayer
     from dataloader import FileDatasetsIter, worker_init_fn
     from model import Brain, DQN
@@ -184,7 +184,7 @@ def train():
 
                     mu_mortal, logsig_mortal = mortal(obs)
                     dist_mortal = Normal(mu_mortal, logsig_mortal.exp())
-                    kld_loss = kl_divergence(dist, dist_mortal).sum(-1).mean()
+                    kld_loss = normal_kl_div(mu, logsig, mu_mortal, logsig_mortal).sum(-1).mean()
                     beta_loss = log_beta * (log10_kld_target - kld_loss.detach().clamp(1e-9).log10())
 
                     loss = sum((


### PR DESCRIPTION
…better numerical stability